### PR TITLE
Fix confusing commented code

### DIFF
--- a/docs/developers/framework/models.html.md
+++ b/docs/developers/framework/models.html.md
@@ -113,7 +113,8 @@ public function Edit($BlogID = '') {
    $Validation = new Gdn_Validation();
    $BlogModel = new Gdn_Model('Blog', $Validation);
 
-   <strong>// Load the blog being edited $Blog = $BlogModel ->GetWhere(array('BlogID' => $BlogID)) ->FirstRow();</strong>
+   // Load the blog being edited 
+   $Blog = $BlogModel ->GetWhere(array('BlogID' => $BlogID)) ->FirstRow();
 
    // Set the BlogModel on the form.
    $this->Form->SetModel($BlogModel);


### PR DESCRIPTION
`<strong>` tags don't need to be there, since they make reading confusing.
Also, `$Body` gets commented out and lower down the document it gets called which is also confusing.